### PR TITLE
Fix tests in Rakefile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -8,7 +8,7 @@ namespace(:test) do
   desc "Run all tests"
   task(:all) do
     tests = Dir['test/**/test_*.rb'] - ['test/test_helper.rb']
-    cmd = "ruby -rubygems -I.:lib -e'%w( #{tests.join(' ')} ).each {|file| require file }'"
+    cmd = "ruby -I.:lib -e'%w( #{tests.join(' ')} ).each {|file| require file }'"
     puts(cmd) if ENV['VERBOSE']
     exit system(cmd)
   end


### PR DESCRIPTION
`-rubygems` is interpreted as `-r ubygems` and generates the following error:

```
<internal:/usr/lib/ruby/3.0.0/rubygems/core_ext/kernel_require.rb>:85:in `require': cannot load such file -- ubygems (LoadError)
Did you mean?  rubygems
        from <internal:/usr/lib/ruby/3.0.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
```

Removing it altogether works fine here.