### PR TITLE
Fix warnings for minitest 5+

### DIFF
--- a/test/test_nanotest.rb
+++ b/test/test_nanotest.rb
@@ -16,7 +16,7 @@ class Foo
   include Nanotest
 end
 
-class TestNanotest < MiniTest::Unit::TestCase
+class TestNanotest < MiniTest::Test
   def self.test(name, &block)
     define_method("test_#{name.gsub(/\s/,'_')}", &block)
   end


### PR DESCRIPTION
Fixes the following warning:

```
MiniTest::Unit::TestCase is now Minitest::Test. From /build/ruby-nanotest/src/nanotest-0.9.4.1/test/test_nanotest.rb:20:in `<top (required)>'
```